### PR TITLE
chore: ability to install wal-e using virtualenv if needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,17 @@ wal_e_pips:
 
 wal_e_version: 0.9.2
 
+# wal-e < 1.0.0 needs python2.7
+# wal-e >= 1.0.0 needs python3.4
+#
+# Set wal_e_virtualenv_python_version if the system python version
+# is not compatible with the wal-e version and if you want to use virtualenv.
+#
+# If not set, wal-e will be installed with defaults system pip and python.
+# If wal_e_version is 1.0.0 => wal_e_virtualenv_python_version must be "python3.4"
+wal_e_virtualenv_python_version: ""
+wal_e_virtualenv_path: "/usr/wal_e_{{ wal_e_virtualenv_python_version }}_virtual_env"
+
 wal_e_envdir: '/etc/wal-e'
 
 wal_e_base_backup_disabled: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,37 @@
 ---
 # tasks file for wal_e
 
-
 - name: Install dependency packages
   package: update_cache=true name="{{ item }}"
   with_items: "{{ wal_e_packages }}"
 
+- name: install virtualenv if needed
+  pip: name=virtualenv state=present
+  when: wal_e_virtualenv_python_version is defined and wal_e_virtualenv_python_version != ''
+
 - name: install python dependency modules with pip
-  pip: name="{{ item }}"
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{% if wal_e_virtualenv_python_version is defined and wal_e_virtualenv_python_version != \"\" %}{{ wal_e_virtualenv_path }}{% endif %}"
+    virtualenv_python: "{{ wal_e_virtualenv_python_version }}"
   with_items: "{{ wal_e_pips }}"
   when: wal_e_pips
 
 - name: install wal-e from pip
-  pip: name="wal-e" version="{{ wal_e_version | default(none) }}"
+  pip:
+    name: "wal-e"
+    version: "{{ wal_e_version | default(none) }}"
+    virtualenv: "{% if wal_e_virtualenv_python_version is defined and wal_e_virtualenv_python_version != \"\" %}{{ wal_e_virtualenv_path }}{% endif %}"
+    virtualenv_python: "{{ wal_e_virtualenv_python_version }}"
   when: wal_e_pips
+
+- name: symlink wal-e in /bin if installed in virtualenv
+  file:
+    src: "{{ wal_e_virtualenv_path }}/bin/wal-e"
+    dest: /bin/wal-e
+    state: link
+    force: yes
+  when: wal_e_virtualenv_python_version is defined and wal_e_virtualenv_python_version != ''
 
 - name: create wal-e envdir for configuration
   file: path="{{ wal_e_envdir }}" state=directory owner="{{ wal_e_user}}" group="{{ wal_e_group }}"


### PR DESCRIPTION
# Description
The default python version on CentOS 7 is python2.7 but wal-e 1.0.0 needs python3.4. We want to have the ability to install wal-e in a virtualenv if we don't want to upgrade python for the entire system.

Sorry for the labels (I'm not admin on the project).