### PR TITLE
fix/avoid aws creds error when using gs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,7 @@ wal_e_user: 'postgres'
 wal_e_group: 'postgres'
 wal_e_pgdata_dir: '/var/lib/postgresql/9.1/main/'
 
-wal_e_s3_prefix: 's3://some-bucket/directory/or/whatever'
+#wal_e_s3_prefix: 's3://some-bucket/directory/or/whatever'
 
 # Set it to true to enable IAM instance profiles.
 # More info: https://github.com/wal-e/wal-e#using-aws-iam-instance-profiles
@@ -67,5 +67,5 @@ wal_e_aws_instance_profile: false
 
 # AWS credentials.
 # Recommended store this using ansible-vault (http://docs.ansible.com/playbooks_vault.html)
-wal_e_aws_access_key:
-wal_e_aws_secret_key:
+#wal_e_aws_access_key:
+#wal_e_aws_secret_key:


### PR DESCRIPTION
**Description**
In order to use google storage we need to set only WALE_GS_PREFIX and GOOGLE_APPLICATION_CREDENTIALS variables. But the three empty defined variables (wal_e_s3_prefix, wal_e_aws_access_key and wal_e_aws_secret_key) generates an error because they are empty (but defined) in "setup AWS credentials AWS_SECRET_ACCESS_KEY" tasks. We could set dummy values for these variables but they will appears in /etc/wal-e env dir and we don't want that.